### PR TITLE
Syntax highlighting for reactive/interpolated attributes

### DIFF
--- a/syntaxes/embedded-html.json
+++ b/syntaxes/embedded-html.json
@@ -1,5 +1,8 @@
 {
-  "fileTypes": ["js", "ts"],
+  "fileTypes": [
+    "js",
+    "ts"
+  ],
   "injectionSelector": "L:source.js -comment -string, L:source.ts -comment -string",
   "patterns": [
     {
@@ -12,6 +15,25 @@
         {
           "match": ":",
           "name": "punctuation.special.colon"
+        }
+      ]
+    },
+    {
+      "begin": "(:[A-Za-z0-9:.-_@]+)\\s*=\\s*\"",
+      "beginCaptures": {
+        "1": {
+          "name": "variable.language"
+        }
+      },
+      "end": "\"(?=\\s|>)",
+      "contentName": "string.quoted.double",
+      "patterns": [
+        {
+          "match": "\\$[A-Za-z0-9:.-_@]+",
+          "name": "variable.parameter"
+        },
+        {
+          "include": "source.js"
         }
       ]
     }


### PR DESCRIPTION
Updated our grammar file to enable syntax highlighting for reactive/interpolated attributes and their values. Here are the rules:

### Reactive/Interpolated attribute names

If an attribute starts with `:` the scope assigned to `variable.language` which is displayed in a different color than normal attributes in popular VSCode themes. Some other scope name alternative can be one of `entity.name.*` scopes. But most of the `entity.name.` scope names are not highlighted in different colours than regular attributes. Here is the explanation for that:

>Historically, many color schemes have provided one color for entity.name.function and entity.name.type, and often a different color for entity.name.tag. This leaves new entity.name.* scopes un-highlighted.
https://www.sublimetext.com/docs/scope_naming.html#entity-name-colors

So, for displaying special attributes in different colours, we can set the scope to :

`entity.name.tag` => the same color of XML tag applied
`entity.name.function` => different colouring and implementations exist among different themes
`entity.name.type` => implementation varies

### `$myVar` like variables as attribute values

If an reactive/interpolated attribute value starts with `$`, the scope is assigned to `variable.parameter` which is displayed in a different colour than string attribute values. 

### JavaScript code as attribute values

If the value of an reactive/interpolated attribute is not a variable and is not a regular string, JavaScript syntax highlighting is used for that attribute values. 

### Test version

I opened this PR to get some comments and reviews about this new setup. Here is a dev version of the extension compressed as a zip file (open the zip file before installing, GitHub does not allow me to attach `.vsix` files)

[lightning-blits-pr-13.vsix.zip](https://github.com/lightning-js/blits-vscode-extension/files/14187826/lightning-blits-pr-13.vsix.zip)

