### PR TITLE
Release - v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## v0.5.0
+
+- added support for block comments
+- added auto template formating on save feature and the corresponding settings ([#17](https://github.com/lightning-js/blits-vscode-extension/issues/17))
+- fixed auto insertion of default values of props
+- improved indentation while commenting out template code
+- added syntax highlighting for reactive/interpolated attributes ([#15](https://github.com/lightning-js/blits-vscode-extension/issues/15))
+- fixed syntax highlighting for `align` attribute ([#19](https://github.com/lightning-js/blits-vscode-extension/issues/15))
+
 ## v0.4.1
 
 - fixed IntelliSense suggestions for TypeScript projects

--- a/README.md
+++ b/README.md
@@ -26,11 +26,13 @@ The extension includes an auto-format feature for the template definitions in Bl
 
 When you save a Blits component file (.js or .ts), the extension automatically formats the template sections within the file. This ensures that your templates are consistently styled and easy to read. The formatting applies only to the template parts of your file, leaving the rest of your JavaScript or TypeScript code unchanged.
 
+You can disable this feature by setting the `blits.autoFormat` configuration option to `false`.
+
 The extension provides several configuration options to customize the auto-formatting feature. These settings allow you to tailor the formatting to your coding style and preferences.
 
 #### Available Settings
 
-###### Print Width (`blits.format.printWidth`): 80
+###### Print Width (`blits.format.printWidth`): 120
 The line length that the printer will wrap on. 
 
 ###### Tab Width (`blits.format.tabWidth`): 2
@@ -63,7 +65,7 @@ Put the `>` of a multi-line tag at the end of the last line instead of being alo
 
 #### Customizing Settings
 
-To customize these settings, follow these steps:
+To customize these settings, you can either modify the `.vscode/settings.json` file directly or use the VSCode settings UI. To do this using the settings UI, follow these steps:
 
 - Open your VSCode settings (either user or workspace settings).
 - Search for `Blits` to find all the relevant settings for the Blits extension.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,59 @@ This extension enables syntax highlighting for the template in your Blits compon
 
 ### Code Completion
 
-The extension offers context-aware IntelliSense for thew Blits framework, focusing specifically on component properties and names within template definitions. For code outside of these templates, the extension defers to VSCode's built-in IntelliSense.
+The extension offers context-aware IntelliSense for the Blits framework, focusing specifically on component properties and names within template definitions. For code outside of these templates, the extension defers to VSCode's built-in IntelliSense.
 
 The code completion feature is designed to avoid suggesting duplicate component properties, providing a cleaner and more efficient coding experience.
 
+### Commenting
+
+The extension introduces an enhanced commenting feature for the XML-style templates within Blits components. Integrated seamlessly with the standard VSCode commenting shortcuts, this feature activates when the cursor is positioned within a Blits template or when a block of code within a template is selected. It enables rapid toggling of HTML-style comments (`<!--` and `-->`) without the need for manual insertion. 
+
+### Format-on-Save
+
+The extension includes an auto-format feature for the template definitions in Blits components. This feature enhances the development experience by automatically formatting the templates upon saving the file.
+
+When you save a Blits component file (.js or .ts), the extension automatically formats the template sections within the file. This ensures that your templates are consistently styled and easy to read. The formatting applies only to the template parts of your file, leaving the rest of your JavaScript or TypeScript code unchanged.
+
+The extension provides several configuration options to customize the auto-formatting feature. These settings allow you to tailor the formatting to your coding style and preferences.
+
+#### Available Settings
+
+###### Print Width (`blits.format.printWidth`): 80
+The line length that the printer will wrap on. 
+
+###### Tab Width (`blits.format.tabWidth`): 2
+Indentation size.
+
+###### Indent with Tabs (`blits.format.useTabs`): `false`
+When `true`, indents with tabs instead of spaces. 
+
+###### Print Semicolons (`blits.format.semi`): `false`
+Print semicolons at the ends of statements.
+
+###### Use Single Quotes (`blits.format.singleQuote`): `true`
+Use single quotes instead of double quotes.
+
+###### Quoting Props (`blits.format.quoteProps`): `as-needed`
+When `as-needed`, adds quotes around object properties where required.    
+When `consistent`, adds quotes around object properties where required, but only if your file contains a mix of quoted and unquoted properties.    
+When `preserve`, keeps object properties unquoted.   
+
+###### Trailing Comma (`blits.format.trailingComma`): `all`
+When `all`, adds trailing commas wherever possible.    
+When `none`, removes trailing commas.    
+When `es5`, adds trailing commas wherever possible, but avoids adding trailing commas to function parameters.
+
+###### Bracket Spacing (`blits.format.bracketSpacing`): `true`
+Print spaces between brackets in object literals.
+
+###### Bracket Same Line (`blits.format.bracketSameLine`): `false`
+Put the `>` of a multi-line tag at the end of the last line instead of being alone on the next line.
+
+#### Customizing Settings
+
+To customize these settings, follow these steps:
+
+- Open your VSCode settings (either user or workspace settings).
+- Search for `Blits` to find all the relevant settings for the Blits extension.
+- Modify the settings as needed. Changes will be applied immediately.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "lightning-blits",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lightning-blits",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "dependencies": {
         "@babel/parser": "^7.22.11",
-        "@babel/traverse": "^7.22.17",
-        "fs-extra": "^11.1.1"
+        "@babel/traverse": "^7.23.2",
+        "fs-extra": "^11.1.1",
+        "prettier": "^2.8.8"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.1",
@@ -23,7 +24,6 @@
         "eslint-plugin-prettier": "^4.2.1",
         "glob": "^10.3.3",
         "mocha": "^10.2.0",
-        "prettier": "^2.8.8",
         "typescript": "^5.1.6"
       },
       "engines": {
@@ -40,11 +40,11 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
       "dependencies": {
-        "@babel/highlight": "^7.22.13",
+        "@babel/highlight": "^7.23.4",
         "chalk": "^2.4.2"
       },
       "engines": {
@@ -116,11 +116,11 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.15.tgz",
-      "integrity": "sha512-Zu9oWARBqeVOW0dZOjXc3JObrzuqothQ3y/n1kUtrjCoCPLkXUwMvOo/F/TCfoHMbWIFlWwpZtkZVb9ga4U2pA==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+      "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
       "dependencies": {
-        "@babel/types": "^7.22.15",
+        "@babel/types": "^7.23.6",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -130,20 +130,20 @@
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
-      "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-      "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
       "dependencies": {
-        "@babel/template": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.23.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -172,27 +172,27 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+      "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.15.tgz",
-      "integrity": "sha512-4E/F9IIEi8WR94324mbDUMo074YTheJmd7eZF5vITTeYchqAi6sYXRLHUVsmkdmY4QjfKTcB2jB7dVP3NaBElQ==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.13.tgz",
-      "integrity": "sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
@@ -265,9 +265,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.16",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.16.tgz",
-      "integrity": "sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.9.tgz",
+      "integrity": "sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -276,31 +276,31 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.23.9.tgz",
+      "integrity": "sha512-+xrD2BWLpvHKNmX2QbpdpsBaWnRxahMwJjO+KZk2JOElj5nSmKezyS1B4u+QbHMTX69t4ukm6hh9lsYQ7GHCKA==",
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/code-frame": "^7.23.5",
+        "@babel/parser": "^7.23.9",
+        "@babel/types": "^7.23.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.22.17",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.17.tgz",
-      "integrity": "sha512-xK4Uwm0JnAMvxYZxOVecss85WxTEIbTa7bnGyf/+EgCL5Zt3U7htUpEOWv9detPlamGKuRzCqw74xVglDWpPdg==",
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.22.15",
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-function-name": "^7.22.5",
+        "@babel/generator": "^7.23.0",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.22.16",
-        "@babel/types": "^7.22.17",
+        "@babel/parser": "^7.23.0",
+        "@babel/types": "^7.23.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -317,12 +317,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.22.17",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.17.tgz",
-      "integrity": "sha512-YSQPHLFtQNE5xN9tHuZnzu8vPr61wVTBZdfv1meex1NBosa4iT05k/Jw06ddJugi4bk7The/oSwQGFcksmEJQg==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.9.tgz",
+      "integrity": "sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.15",
+        "@babel/helper-string-parser": "^7.23.4",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -849,9 +849,9 @@
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
-      "integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
+      "version": "0.3.22",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz",
+      "integrity": "sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -2466,7 +2466,6 @@
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -3155,11 +3154,11 @@
       "dev": true
     },
     "@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
       "requires": {
-        "@babel/highlight": "^7.22.13",
+        "@babel/highlight": "^7.23.4",
         "chalk": "^2.4.2"
       },
       "dependencies": {
@@ -3215,28 +3214,28 @@
       }
     },
     "@babel/generator": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.15.tgz",
-      "integrity": "sha512-Zu9oWARBqeVOW0dZOjXc3JObrzuqothQ3y/n1kUtrjCoCPLkXUwMvOo/F/TCfoHMbWIFlWwpZtkZVb9ga4U2pA==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+      "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
       "requires": {
-        "@babel/types": "^7.22.15",
+        "@babel/types": "^7.23.6",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
       }
     },
     "@babel/helper-environment-visitor": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
-      "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q=="
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA=="
     },
     "@babel/helper-function-name": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-      "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
       "requires": {
-        "@babel/template": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.23.0"
       }
     },
     "@babel/helper-hoist-variables": {
@@ -3256,21 +3255,21 @@
       }
     },
     "@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw=="
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+      "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ=="
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.15.tgz",
-      "integrity": "sha512-4E/F9IIEi8WR94324mbDUMo074YTheJmd7eZF5vITTeYchqAi6sYXRLHUVsmkdmY4QjfKTcB2jB7dVP3NaBElQ=="
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A=="
     },
     "@babel/highlight": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.13.tgz",
-      "integrity": "sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
@@ -3327,33 +3326,33 @@
       }
     },
     "@babel/parser": {
-      "version": "7.22.16",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.16.tgz",
-      "integrity": "sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA=="
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.9.tgz",
+      "integrity": "sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA=="
     },
     "@babel/template": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.23.9.tgz",
+      "integrity": "sha512-+xrD2BWLpvHKNmX2QbpdpsBaWnRxahMwJjO+KZk2JOElj5nSmKezyS1B4u+QbHMTX69t4ukm6hh9lsYQ7GHCKA==",
       "requires": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/code-frame": "^7.23.5",
+        "@babel/parser": "^7.23.9",
+        "@babel/types": "^7.23.9"
       }
     },
     "@babel/traverse": {
-      "version": "7.22.17",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.17.tgz",
-      "integrity": "sha512-xK4Uwm0JnAMvxYZxOVecss85WxTEIbTa7bnGyf/+EgCL5Zt3U7htUpEOWv9detPlamGKuRzCqw74xVglDWpPdg==",
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
       "requires": {
         "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.22.15",
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-function-name": "^7.22.5",
+        "@babel/generator": "^7.23.0",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.22.16",
-        "@babel/types": "^7.22.17",
+        "@babel/parser": "^7.23.0",
+        "@babel/types": "^7.23.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -3366,12 +3365,12 @@
       }
     },
     "@babel/types": {
-      "version": "7.22.17",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.17.tgz",
-      "integrity": "sha512-YSQPHLFtQNE5xN9tHuZnzu8vPr61wVTBZdfv1meex1NBosa4iT05k/Jw06ddJugi4bk7The/oSwQGFcksmEJQg==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.9.tgz",
+      "integrity": "sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==",
       "requires": {
-        "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.15",
+        "@babel/helper-string-parser": "^7.23.4",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -3647,9 +3646,9 @@
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
-      "integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
+      "version": "0.3.22",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz",
+      "integrity": "sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==",
       "requires": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -4850,8 +4849,7 @@
     "prettier": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "dev": true
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -60,9 +60,14 @@
     "configuration": {
       "title": "Blits Extension Settings",
       "properties": {
+        "blits.autoFormat": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically format the document on save."
+        },
         "blits.format.printWidth": {
           "type": "number",
-          "default": 80,
+          "default": 120,
           "description": "The line length that the printer will wrap on",
           "minimum": 20,
           "maximum": 1000

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "lightningjs",
   "displayName": "Lightning Blits",
   "description": "Template syntax highlighting and code completion for the Lightning Blits framework",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/lightning-js/blits-vscode-extension.git"
@@ -56,12 +56,105 @@
         "command": "blits-vscode.commentCommand",
         "when": "editorTextFocus && (editorLangId == 'javascript' || editorLangId == 'typescript')"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Blits Extension Settings",
+      "properties": {
+        "blits.format.printWidth": {
+          "type": "number",
+          "default": 80,
+          "description": "The line length that the printer will wrap on",
+          "minimum": 20,
+          "maximum": 1000
+        },
+        "blits.format.tabWidth": {
+          "type": "number",
+          "default": 2,
+          "description": "Indentation size.",
+          "minimum": 0,
+          "maximum": 8
+        },
+        "blits.format.useTabs": {
+          "type": "boolean",
+          "default": false,
+          "description": "Indent lines with tabs instead of spaces."
+        },
+        "blits.format.semi": {
+          "type": "boolean",
+          "default": false,
+          "description": "Print semicolons at the ends of statements."
+        },
+        "blits.format.singleQuote": {
+          "type": "boolean",
+          "default": true,
+          "description": "Use single quotes instead of double quotes."
+        },
+        "blits.format.quoteProps": {
+          "type": "string",
+          "default": "as-needed",
+          "enum": [
+            "as-needed",
+            "consistent",
+            "preserve"
+          ],
+          "enumDescriptions": [
+            "Only add quotes around object properties where required",
+            "If at least one property in an object requires quotes, quote all properties",
+            "Respect the input use of quotes in object properties"
+          ],
+          "description": "Change when properties in objects are quoted."
+        },
+        "blits.format.trailingComma": {
+          "type": "string",
+          "default": "all",
+          "enum": [
+            "all",
+            "es5",
+            "none"
+          ],
+          "enumDescriptions": [
+            "Trailing commas wherever possible",
+            "Trailing commas where valid in ES5",
+            "No trailing commas"
+          ],
+          "description": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures."
+        },
+        "blits.format.bracketSpacing": {
+          "type": "boolean",
+          "default": true,
+          "description": "Print spaces between brackets in object literals."
+        },
+        "blits.format.bracketSameLine": {
+          "type": "boolean",
+          "default": false,
+          "description": "Put the > of a multi-line tag at the end of the last line instead of being alone on the next line."
+        },
+        "blits.format.arrowParens": {
+          "type": "string",
+          "default": "always",
+          "enum": [
+            "always",
+            "avoid"
+          ],
+          "enumDescriptions": [
+            "Always include parentheses",
+            "Omit parentheses when possible"
+          ],
+          "description": "Include parentheses around a sole arrow function parameter."
+        },
+        "blits.format.singleAttributePerLine": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enforce single attribute per line in templates."
+        }
+      }
+    }
   },
   "dependencies": {
     "@babel/parser": "^7.22.11",
-    "@babel/traverse": "^7.22.17",
-    "fs-extra": "^11.1.1"
+    "@babel/traverse": "^7.23.2",
+    "fs-extra": "^11.1.1",
+    "prettier": "^2.8.8"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.1",
@@ -74,7 +167,6 @@
     "eslint-plugin-prettier": "^4.2.1",
     "glob": "^10.3.3",
     "mocha": "^10.2.0",
-    "prettier": "^2.8.8",
     "typescript": "^5.1.6"
   }
 }

--- a/src/completionItems/componentProps.js
+++ b/src/completionItems/componentProps.js
@@ -54,7 +54,7 @@ module.exports = async (tag, attributes, doc, docAst) => {
               vscode.CompletionItemKind.Property
             )
             completionItem.insertText = new vscode.SnippetString(
-              `${prop.key}="$0"`
+              `${prop.key}="${prop.default ? prop.default : ''}$0"`
             )
             completionItem.sortText = '0' + prop.key
             completionItems.push(completionItem)

--- a/src/completionItems/elementProps.js
+++ b/src/completionItems/elementProps.js
@@ -36,7 +36,7 @@ const elementProps = [
   'pivot',
   'src',
   'ref',
-  'effects'
+  'effects',
 ]
 
 module.exports = async (attributes) => {

--- a/src/formatters/index.js
+++ b/src/formatters/index.js
@@ -15,28 +15,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const completionProviders = require('./completionProviders')
-const commands = require('./commands')
-const formatters = require('./formatters')
-
-function activate(context) {
-  // add completion provider for template section
-  context.subscriptions.push(completionProviders.templateAttributes)
-
-  // comment command wrapper for template section
-  context.subscriptions.push(commands.commentCommand)
-
-  // format template section on save
-  context.subscriptions.push(formatters.templateFormatterOnSave)
-
-  console.log('Lightning Blits has been activated.')
-}
-
-function deactivate() {
-  console.log('Lightning Blits has been deactivated.')
-}
-
 module.exports = {
-  activate,
-  deactivate,
+  templateFormatterOnSave: require('./templateFormatterOnSave'),
 }

--- a/src/formatters/templateFormatterOnSave.js
+++ b/src/formatters/templateFormatterOnSave.js
@@ -34,6 +34,15 @@ const configKeys = [
 ]
 
 module.exports = vscode.workspace.onWillSaveTextDocument((event) => {
+  // check if auto format is enabled
+  const autoFormatEnabled = vscode.workspace
+    .getConfiguration('blits')
+    .get('autoFormat')
+
+  if (!autoFormatEnabled) {
+    return
+  }
+
   const document = event.document
   const currentDoc = document.getText()
   const fileExtension = document.uri.fsPath.split('.').pop()
@@ -61,7 +70,9 @@ module.exports = vscode.workspace.onWillSaveTextDocument((event) => {
       const extraIndentation = ' '.repeat(4)
       formattedTemplate =
         extraIndentation +
-        formattedTemplate.replace(/\n/g, `\n${extraIndentation}`)
+        formattedTemplate
+          .replace(/\n/g, `\n${extraIndentation}`)
+          .replace(/[\t ]+$/, '  ') // indent 2 spaces if the last line only contains a newline/space/tab
 
       // add template key and possible comment back
       formattedTemplate = `${stringChar}\n${formattedTemplate}${stringChar}`

--- a/src/formatters/templateFormatterOnSave.js
+++ b/src/formatters/templateFormatterOnSave.js
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const vscode = require('vscode')
+const parse = require('../parsers')
+const templateHelper = require('../helpers/template')
+const prettier = require('prettier')
+const configKeys = [
+  'printWidth',
+  'tabWidth',
+  'useTabs',
+  'semi',
+  'singleQuote',
+  'quoteProps',
+  'trailingComma',
+  'bracketSpacing',
+  'backetSameLine',
+  'arrowParens',
+  'singleAttributePerLine',
+]
+
+module.exports = vscode.workspace.onWillSaveTextDocument((event) => {
+  const document = event.document
+  const currentDoc = document.getText()
+  const fileExtension = document.uri.fsPath.split('.').pop()
+  const currentDocAst = parse.AST(currentDoc, fileExtension)
+  const templates = templateHelper.getTemplateText(currentDocAst, currentDoc)
+
+  let edits = []
+
+  if (templates.length > 0) {
+    templates.forEach((templateObject) => {
+      const { start, end, template } = templateObject
+      const stringChar = template.slice(-1)
+
+      // remove first and last character (`, ', ", ``, '', "")
+      const templateText = template.slice(1, -1)
+      const config = getAutoFormatConfig()
+      let formattedTemplate = prettier.format(templateText, {
+        parser: 'angular',
+        ...config,
+      })
+
+      console.log('formattedTemplate', formattedTemplate)
+
+      // add extra indentation for all lines (4 spaces)
+      const extraIndentation = ' '.repeat(4)
+      formattedTemplate =
+        extraIndentation +
+        formattedTemplate.replace(/\n/g, `\n${extraIndentation}`)
+
+      // add template key and possible comment back
+      formattedTemplate = `${stringChar}\n${formattedTemplate}${stringChar}`
+
+      const startPosition = document.positionAt(start)
+      const endPosition = document.positionAt(end)
+
+      const edit = new vscode.TextEdit(
+        new vscode.Range(startPosition, endPosition),
+        formattedTemplate
+      )
+      edits.push(edit)
+    })
+  }
+
+  if (edits.length > 0) {
+    event.waitUntil(Promise.resolve(edits))
+  }
+})
+
+function getAutoFormatConfig() {
+  const config = vscode.workspace.getConfiguration('blits.format')
+  let allSettings = {}
+  configKeys.forEach((key) => {
+    if (Object.prototype.hasOwnProperty.call(config, key)) {
+      allSettings[key] = config.get(key)
+    }
+  })
+  return allSettings
+}

--- a/src/helpers/template.js
+++ b/src/helpers/template.js
@@ -36,6 +36,44 @@ const findTemplateRange = (ast) => {
   return { start: 0, end: 0 }
 }
 
+// const getTemplateText = (editorText) => {
+//   const templateSectionRegex =
+//     /template\s*:\s*(?:\/\*.*?\*\/)?\s*[`']([\s\S]*)[`']/g
+//   const matches = templateSectionRegex.exec(editorText)
+
+//   if (matches && matches[1]) {
+//     return matches[1]
+//   }
+//   return ''
+// }
+
+const getTemplateText = (ast, sourceCode) => {
+  let templateTexts = []
+
+  if (ast) {
+    traverse(ast, {
+      ObjectProperty(path) {
+        if (path.node.key.name === 'template') {
+          const templateNode = path.node.value
+          // Extract the range of the template string
+          const start = templateNode.start
+          const end = templateNode.end
+
+          // Extract the text from the source code
+          const templateText = sourceCode.substring(start, end)
+          templateTexts.push({
+            start,
+            end,
+            template: templateText,
+          })
+        }
+      },
+    })
+  }
+
+  return templateTexts
+}
+
 const findComponentFileByName = (ast, tag) => {
   let file = null
   if (ast) {
@@ -103,4 +141,5 @@ module.exports = {
   isCursorInsideTemplate,
   getExistingTagAndAttributes,
   findComponentFileByName,
+  getTemplateText,
 }

--- a/syntaxes/embedded-html.json
+++ b/syntaxes/embedded-html.json
@@ -1,5 +1,8 @@
 {
-  "fileTypes": ["js", "ts"],
+  "fileTypes": [
+    "js",
+    "ts"
+  ],
   "injectionSelector": "L:source.js -comment -string, L:source.ts -comment -string",
   "patterns": [
     {
@@ -14,6 +17,35 @@
           "name": "punctuation.special.colon"
         }
       ]
+    },
+    {
+      "begin": "(:[A-Za-z0-9:.-_@]+)\\s*=\\s*\"",
+      "beginCaptures": {
+        "1": {
+          "name": "variable.language"
+        }
+      },
+      "end": "\"(?=\\s|>)",
+      "contentName": "string.quoted.double",
+      "patterns": [
+        {
+          "match": "\\$[A-Za-z0-9:.-_@]+",
+          "name": "variable.parameter"
+        },
+        {
+          "include": "source.js"
+        }
+      ]
+    },
+    {
+      "begin": "\\s+(align)\\s*=\\s*\"",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.other.attribute-name.html"
+        }
+      },
+      "end": "\"(?=\\s|>)",
+      "contentName": "string.quoted.double"
     }
   ],
   "scopeName": "inline.custom-blits-html"


### PR DESCRIPTION
- added support for block comments
- added auto template formating on save feature and the corresponding settings ([#17](https://github.com/lightning-js/blits-vscode-extension/issues/17))
- fixed auto insertion of default values of props
- improved indentation while commenting out template code
- added syntax highlighting for reactive/interpolated attributes ([#15](https://github.com/lightning-js/blits-vscode-extension/issues/15))
- fixed syntax highlighting for `align` attribute ([#19](https://github.com/lightning-js/blits-vscode-extension/issues/15))

### Updates
- added `blits.autoFormat` option to enable/disable the auto template formatting feature. It is enabled by default.
- Fixed indentation issue of the last empty line of template string (that just contains white space, quoting character and a comma), not it is being properly indented.
- Changed default value for `blits.format.printWidth` by making the default value `120`
- All the extension settings can be defined in `.vscode/settings.json` so different projects can have different settings.
- Fixed a bug that causes the extension to incorrectly identify regular JavaScript code that includes `template` key as Blits template definitions due to loose AST parsing rules. Now, AST parser checks if `template` is defined inside the passed argument of either `Blits.Component` or `Blits.Application`.


In order to test, unzip the following file and install the extension (updated file) : 
[lightning-blits-0.5.0.vsix.zip](https://github.com/lightning-js/blits-vscode-extension/files/14649252/lightning-blits-0.5.0.vsix.zip)

