### PR TITLE
Release - v1.2.1 - hotfix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lightning-blits",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lightning-blits",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "Apache-2",
       "dependencies": {
         "@babel/traverse": "^7.23.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "lightningjs",
   "displayName": "Lightning Blits",
   "description": "Template syntax highlighting and code completion for the Lightning Blits framework",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/lightning-js/blits-vscode-extension.git"

--- a/src/completionProviders/templateTags.js
+++ b/src/completionProviders/templateTags.js
@@ -344,7 +344,6 @@ const getCompletionItems = async (document, currentDoc, position, isBlits, fileP
 
   if (isCursorInsideTemplate) {
     const componentData = await analyzeBlitsComponent(currentDoc, fileExt, filePath)
-    console.log(JSON.stringify(componentData, null, 2))
     return await completionItems.componentNames.suggest(componentData)
   }
 

--- a/src/parsers/ast.js
+++ b/src/parsers/ast.js
@@ -18,7 +18,7 @@
 const parser = require('@babel/parser')
 
 const parseAST = (code, fileExtension) => {
-  const pluginList = ['objectRestSpread', 'optionalChaining', 'nullishCoalescingOperator', 'flow']
+  const pluginList = ['objectRestSpread', 'optionalChaining', 'nullishCoalescingOperator']
 
   if (fileExtension === 'ts' || fileExtension === 'tsx') {
     pluginList.push('typescript')


### PR DESCRIPTION
Removes an babel plugin that is incompatible for TypeScript parsing.

**Test version for v1.2.1**

[lightning-blits-1.2.1.vsix.zip](https://github.com/user-attachments/files/18059692/lightning-blits-1.2.1.vsix.zip)
